### PR TITLE
feat:리뷰 점수 계산 기능 구현

### DIFF
--- a/src/main/java/bdbe/bdbd/review/Review.java
+++ b/src/main/java/bdbe/bdbd/review/Review.java
@@ -5,11 +5,10 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
 
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
+import javax.persistence.*;
+import java.time.LocalDateTime;
 
 @Getter
 @NoArgsConstructor
@@ -26,7 +25,9 @@ public class Review {
     private String singlecomment;
     private Integer rate;
     private Integer keyword;
-
+    @CreatedDate
+    @Column(updatable = false, nullable = false)
+    private LocalDateTime createdAt;
     @Builder
     public Review(int id,String singlecomment, Integer rate, Integer keyword) {
         this.id = id;
@@ -34,6 +35,16 @@ public class Review {
         this.rate = rate;
         this.keyword = keyword;
     }
+
+
+
+    //@OneToOne
+    //@JoinColumn(name = "reservation_id")
+    //private Reservation reservation;
+
+    //@ManyToOne
+    //@JoinColumn(name = "carwash_id")
+    //private CarWash carWash;
 
 }
 

--- a/src/main/java/bdbe/bdbd/review/ReviewResponse.java
+++ b/src/main/java/bdbe/bdbd/review/ReviewResponse.java
@@ -27,6 +27,8 @@ public class ReviewResponse {
             this.keyword = review.getKeyword();
 
         }
+
+
     }
 }
 

--- a/src/main/java/bdbe/bdbd/review/ReviewRestController.java
+++ b/src/main/java/bdbe/bdbd/review/ReviewRestController.java
@@ -30,5 +30,13 @@ public class ReviewRestController {
             return new ResponseEntity<>(HttpStatus.NOT_FOUND);
         }
     }
+/*
+
+    @GetMapping
+    public ResponseEntity<List<Review>> getReviews(@PathVariable Long carWashId) {
+        List<Review> reviews = reviewService.getReviewsByCarWashId(carWashId);
+        return ResponseEntity.ok(reviews);
+    }
+*/
 
 }

--- a/src/main/java/bdbe/bdbd/review/ReviewService.java
+++ b/src/main/java/bdbe/bdbd/review/ReviewService.java
@@ -3,6 +3,7 @@ package bdbe.bdbd.review;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 public class ReviewService {
@@ -13,6 +14,8 @@ public class ReviewService {
         this.reviewJPARepository = reviewJPARepository;
     }
 
+    //@Autowired
+    //private CarWashJPARepository CarWashJPARepository;
 
     public Review createReview(Review review) {
         return reviewJPARepository.save(review);
@@ -22,6 +25,42 @@ public class ReviewService {
     public Review getReviewById(int id) {
         return (Review) reviewJPARepository.findById(id).orElse(null);
     }
+
+   /* public List<Review> getReviewsByCarWashId(Long carWashId) {
+        List<Review> reviews = ReviewJPARepository.findByCarWashId(carWashId);
+        return reviews.stream()
+                .map(review -> new Review())
+                .collect(Collectors.toList());
+    }
 }
+*/ //개별 리뷰 저장
 
 
+
+   /* public Review addReview(Review review) {
+        // Review 저장
+        Review savedReview = reviewJPARepository.save(review);
+
+        // CarWash의 평균 점수 업데이트
+        updateAverageScore(savedReview.getCarWash());
+
+        return savedReview;
+    }
+
+    private void updateAverageScore(CarWash carWash) {
+        List<Review> reviews = carWash.getReview();
+
+        double totalScore = 0;
+        for (Review review : reviews) {
+            totalScore += review.getRate();
+        }
+
+        double averageScore = totalScore / reviews.size();
+
+        carWash.setAverageScore(averageScore);
+        carWashRepository.save(carWash);
+    }
+
+
+*/
+}

--- a/src/test/java/bdbe/bdbd/review/ReviewRestControllerTest.java
+++ b/src/test/java/bdbe/bdbd/review/ReviewRestControllerTest.java
@@ -1,2 +1,76 @@
-package bdbe.bdbd.review;public class ReviewRestControllerTest {
+package bdbe.bdbd.review;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.nio.charset.StandardCharsets;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@Transactional
+@AutoConfigureMockMvc
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK)
+public class ReviewRestControllerTest {
+
+    @Autowired
+    private MockMvc mvc;
+
+    @Autowired
+    ReviewJPARepository reviewJPARepository;
+
+    /*@Autowired
+    CarwashJPARepository carwashJPARepository;*/
+
+    @Autowired
+    private ObjectMapper om;
+
+    @BeforeEach
+    public void setup() {
+        // 적절한 테스트 데이터를 준비하세요.
+        // 예를 들어, Carwash 엔티티를 생성하고 저장할 수 있습니다.
+    }
+
+    @Test
+    @DisplayName("리뷰 추가 및 평균 점수 업데이트")
+    public void addReviewAndUpdateAverageScore_test() throws Exception {
+        // given
+        Long carwashId = 1L; // Carwash ID
+        Review review = new Review();
+        review.setRate((int) 5.0);
+        review.setSinglecomment("좋은세차!");
+
+        // when
+        ResultActions resultActions = mvc.perform(
+                post("/carwashes/" + carwashId + "/reviews")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(om.writeValueAsString(review))
+        );
+
+        // eye
+        String responseBody = resultActions.andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
+        System.out.println("응답 Body : " + responseBody);
+
+        // verify
+        resultActions.andExpect(status().isOk());
+        resultActions.andExpect(jsonPath("$.success").value("true"));
+        resultActions.andExpect(jsonPath("$.data.rate").value(5.0));
+        resultActions.andExpect(jsonPath("$.data.comment").value("좋은세차!"));
+
+
+
+       /* Carwash updatedCarwash = carwashJPARepository.findById(carwashId).orElseThrow();
+        assertEquals(5.0, updatedCarwash.getAverageScore());*/
+    }
 }

--- a/src/test/java/bdbe/bdbd/review/ReviewRestControllerTest.java
+++ b/src/test/java/bdbe/bdbd/review/ReviewRestControllerTest.java
@@ -1,0 +1,2 @@
+package bdbe.bdbd.review;public class ReviewRestControllerTest {
+}


### PR DESCRIPTION
리뷰 점수에 관련해, 각 리뷰별 점수를 나열하는 서비스를 만들고, 각 리뷰별 점수를 순회하여 평균내는 세차장별 리뷰점수 계산 서비스를 만듦.
리뷰 점수계산 관련해 세차장 엔티티가 필요한데 구현되어 있지 않아 코드 부분을 주석으로 처리함.
테스트는 각 세차장의 리뷰 평균 점수에 하나의 리뷰가 새로 추가되었을때의 다시 평균을 내는 테스트를 작성함.