### PR TITLE
feat: 결제 기능 구현

### DIFF
--- a/src/main/java/bdbe/bdbd/_core/errors/config/RestTemplateConfig.java
+++ b/src/main/java/bdbe/bdbd/_core/errors/config/RestTemplateConfig.java
@@ -1,0 +1,30 @@
+package bdbe.bdbd._core.errors.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.web.client.RestTemplate;
+
+import java.net.InetSocketAddress;
+import java.net.Proxy;
+
+@Configuration
+public class RestTemplateConfig {
+
+    @Bean
+    @Profile("prod")
+    public RestTemplate restTemplateForProd() {
+        SimpleClientHttpRequestFactory requestFactory = new SimpleClientHttpRequestFactory();
+        Proxy proxy = new Proxy(Proxy.Type.HTTP, new InetSocketAddress("krmp-proxy.9rum.cc", 3128));
+        requestFactory.setProxy(proxy);
+
+        return new RestTemplate(requestFactory);
+    }
+
+    @Bean
+    @Profile("!prod")
+    public RestTemplate restTemplateForNonProd() {
+        return new RestTemplate();
+    }
+}

--- a/src/main/java/bdbe/bdbd/_core/errors/security/JwtAuthenticationFilter.java
+++ b/src/main/java/bdbe/bdbd/_core/errors/security/JwtAuthenticationFilter.java
@@ -57,6 +57,9 @@ public class JwtAuthenticationFilter extends BasicAuthenticationFilter {
             log.error("토큰 검증 실패", sve);
         } catch (TokenExpiredException tee) {
             log.error("토큰 만료됨", tee);
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+            response.getWriter().write("Failed to get an access token\n" +
+                    "JWT has expired");
         }
         catch (Exception e) {
                 log.error("예상치 못한 오류가 발생했습니다", e);

--- a/src/main/java/bdbe/bdbd/_core/errors/security/SecurityConfig.java
+++ b/src/main/java/bdbe/bdbd/_core/errors/security/SecurityConfig.java
@@ -72,13 +72,13 @@ public class SecurityConfig {
 
         // 인증, 권한 필터 설정: 오너와 사용자 어드민 세가지로 url 접근 수정
         http.authorizeRequests(authorize -> authorize
-                .antMatchers("/owner/join", "/owner/login").permitAll()
-                .antMatchers("/user/join", "/user/login").permitAll()
-                .antMatchers("/admin/join", "/admin/login").permitAll()
-                .antMatchers("/user/check", "/user/check").permitAll()
-                .antMatchers("/owner/check", "/owner/check").permitAll()
-                .antMatchers("/admin/**").access("hasRole('ADMIN')")
-                .antMatchers("/owner/**").access("hasRole('OWNER')")
+                .antMatchers("/api/owner/join", "/api/owner/login").permitAll()
+                .antMatchers("/api/user/join", "/api/user/login").permitAll()
+                .antMatchers("/api/admin/join", "/api/admin/login").permitAll()
+                .antMatchers("/api/user/check", "/api/user/check").permitAll()
+                .antMatchers("/api/owner/check", "/api/owner/check").permitAll()
+                .antMatchers("/api/admin/**").access("hasRole('ADMIN')")
+                .antMatchers("/api/owner/**").access("hasRole('OWNER')")
                 .anyRequest().permitAll());
         return http.build();
     }

--- a/src/main/java/bdbe/bdbd/file/FileJPARepository.java
+++ b/src/main/java/bdbe/bdbd/file/FileJPARepository.java
@@ -3,8 +3,11 @@ package bdbe.bdbd.file;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface FileJPARepository extends JpaRepository<File, Long> {
     List<File> findByCarwash_Id(Long carwashId);
+
+    Optional<File> findFirstByCarwashIdOrderByUploadedAtAsc(Long carwashId);
 
 }

--- a/src/main/java/bdbe/bdbd/pay/PayController.java
+++ b/src/main/java/bdbe/bdbd/pay/PayController.java
@@ -1,0 +1,42 @@
+package bdbe.bdbd.pay;
+
+import bdbe.bdbd._core.errors.security.CustomUserDetails;
+import bdbe.bdbd.carwash.Carwash;
+import bdbe.bdbd.carwash.CarwashService;
+import bdbe.bdbd.reservation.ReservationRequest;
+import bdbe.bdbd.reservation.ReservationService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/payment")
+@RequiredArgsConstructor
+public class PayController {
+
+    private final PayService payService;
+    private final ReservationService reservationService;
+    private final CarwashService carwashService;
+
+    @PostMapping("/ready")
+    public ResponseEntity<String> requestPaymentReady(
+            @RequestBody PayRequest.PaymentReadyRequest paymentReadyRequest) {
+        return payService.requestPaymentReady(
+                paymentReadyRequest.getRequestDto(),
+                paymentReadyRequest.getSaveDTO(),
+                Carwash.builder().build()
+        );
+    }
+
+    @PostMapping("/approve/{carwash_id}/{bay_id}")
+    public ResponseEntity<PayResponse.PaymentAndReservationResponseDTO> requestPaymentApproval(
+            @RequestBody PayRequest.PayApprovalRequestDTO requestDto,
+            @PathVariable("carwash_id") Long carwashId,
+            @PathVariable("bay_id") Long bayId,
+            @RequestBody ReservationRequest.SaveDTO saveDTO,
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+        return payService.requestPaymentApproval(requestDto, carwashId, bayId, userDetails.getMember(), saveDTO);
+    }
+
+}

--- a/src/main/java/bdbe/bdbd/pay/PayController.java
+++ b/src/main/java/bdbe/bdbd/pay/PayController.java
@@ -4,8 +4,10 @@ import bdbe.bdbd._core.errors.security.CustomUserDetails;
 import bdbe.bdbd.carwash.Carwash;
 import bdbe.bdbd.carwash.CarwashService;
 import bdbe.bdbd.reservation.ReservationRequest;
+import bdbe.bdbd.reservation.ReservationResponse;
 import bdbe.bdbd.reservation.ReservationService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -19,24 +21,34 @@ public class PayController {
     private final ReservationService reservationService;
     private final CarwashService carwashService;
 
-    @PostMapping("/ready")
+    @PostMapping("/ready/{carwash_id}")
     public ResponseEntity<String> requestPaymentReady(
+            @PathVariable("carwash_id") Long carwashId,
             @RequestBody PayRequest.PaymentReadyRequest paymentReadyRequest) {
         return payService.requestPaymentReady(
                 paymentReadyRequest.getRequestDto(),
                 paymentReadyRequest.getSaveDTO(),
-                Carwash.builder().build()
+                carwashId
         );
     }
 
     @PostMapping("/approve/{carwash_id}/{bay_id}")
-    public ResponseEntity<PayResponse.PaymentAndReservationResponseDTO> requestPaymentApproval(
-            @RequestBody PayRequest.PayApprovalRequestDTO requestDto,
+    public ResponseEntity<ReservationResponse.findLatestOneResponseDTO> requestPaymentApproval(
             @PathVariable("carwash_id") Long carwashId,
             @PathVariable("bay_id") Long bayId,
-            @RequestBody ReservationRequest.SaveDTO saveDTO,
+            @RequestBody PayRequest.PaymentApprovalRequestDTO requestDTO,
             @AuthenticationPrincipal CustomUserDetails userDetails) {
-        return payService.requestPaymentApproval(requestDto, carwashId, bayId, userDetails.getMember(), saveDTO);
-    }
 
+        if (userDetails == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
+
+        return payService.requestPaymentApproval(
+                requestDTO.getPayApprovalRequestDTO(),
+                carwashId,
+                bayId,
+                userDetails.getMember(),
+                requestDTO.getSaveDTO()
+        );
+    }
 }

--- a/src/main/java/bdbe/bdbd/pay/PayRequest.java
+++ b/src/main/java/bdbe/bdbd/pay/PayRequest.java
@@ -26,28 +26,11 @@ public class PayRequest {
         private String cancel_url;
         private String fail_url;
 
-        public static PayReadyRequestDTO fromSaveDTO(SaveDTO saveDTO, Carwash carwash) {
-            int perPrice = carwash.getPrice();
-            LocalDateTime startTime = saveDTO.getStartTime();
-            LocalDateTime endTime = saveDTO.getEndTime();
-
-            int minutesDifference = (int) ChronoUnit.MINUTES.between(startTime, endTime);
-            int blocksOf30Minutes = minutesDifference / 30;
-            int price = perPrice * blocksOf30Minutes;
-
-            int totalAmount = (int)(price * 1.1);  //세금 포함 가격
-            int vatAmount = (int)(price * 0.1);  // 세금
-
-            PayReadyRequestDTO dto = new PayReadyRequestDTO();
-            dto.setTotal_amount(totalAmount);
-            dto.setVat_amount(vatAmount);
-            return dto;
-        }
     }
 
     @Getter
     @Setter
-    public class PayApprovalRequestDTO {
+    public static class PayApprovalRequestDTO {
         private String cid;
         private String tid;
         private String partner_order_id;
@@ -60,6 +43,14 @@ public class PayRequest {
     public static class PaymentReadyRequest {
         private PayRequest.PayReadyRequestDTO requestDto;
         private ReservationRequest.SaveDTO saveDTO;
+    }
+    @Getter
+    @Setter
+    public static class PaymentApprovalRequestDTO {
+        private PayRequest.PayApprovalRequestDTO payApprovalRequestDTO;
+        private ReservationRequest.SaveDTO saveDTO;
+        private Long carwashId;
+        private Long bayId;
     }
 
 }

--- a/src/main/java/bdbe/bdbd/pay/PayRequest.java
+++ b/src/main/java/bdbe/bdbd/pay/PayRequest.java
@@ -1,0 +1,65 @@
+package bdbe.bdbd.pay;
+
+import bdbe.bdbd.reservation.ReservationRequest;
+import bdbe.bdbd.reservation.ReservationRequest.SaveDTO;
+import bdbe.bdbd.carwash.Carwash;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+
+public class PayRequest {
+
+    @Getter
+    @Setter
+    public static class PayReadyRequestDTO {
+        private String cid;
+        private String partner_order_id;
+        private String partner_user_id;
+        private String item_name;
+        private Integer quantity;
+        private Integer total_amount;
+        private Integer vat_amount;
+        private Integer tax_free_amount;
+        private String approval_url;
+        private String cancel_url;
+        private String fail_url;
+
+        public static PayReadyRequestDTO fromSaveDTO(SaveDTO saveDTO, Carwash carwash) {
+            int perPrice = carwash.getPrice();
+            LocalDateTime startTime = saveDTO.getStartTime();
+            LocalDateTime endTime = saveDTO.getEndTime();
+
+            int minutesDifference = (int) ChronoUnit.MINUTES.between(startTime, endTime);
+            int blocksOf30Minutes = minutesDifference / 30;
+            int price = perPrice * blocksOf30Minutes;
+
+            int totalAmount = (int)(price * 1.1);  //세금 포함 가격
+            int vatAmount = (int)(price * 0.1);  // 세금
+
+            PayReadyRequestDTO dto = new PayReadyRequestDTO();
+            dto.setTotal_amount(totalAmount);
+            dto.setVat_amount(vatAmount);
+            return dto;
+        }
+    }
+
+    @Getter
+    @Setter
+    public class PayApprovalRequestDTO {
+        private String cid;
+        private String tid;
+        private String partner_order_id;
+        private String partner_user_id;
+        private String pg_token;
+    }
+
+    @Getter
+    @Setter
+    public static class PaymentReadyRequest {
+        private PayRequest.PayReadyRequestDTO requestDto;
+        private ReservationRequest.SaveDTO saveDTO;
+    }
+
+}

--- a/src/main/java/bdbe/bdbd/pay/PayResponse.java
+++ b/src/main/java/bdbe/bdbd/pay/PayResponse.java
@@ -66,13 +66,5 @@ public class PayResponse {
         private String card_item_code;
     }
 
-    @Getter
-    @Setter
-    public static class PaymentAndReservationResponseDTO {
-        private String paymentApprovalResponse;
-        private Reservation reservation;
-    }
-
-
 
 }

--- a/src/main/java/bdbe/bdbd/pay/PayResponse.java
+++ b/src/main/java/bdbe/bdbd/pay/PayResponse.java
@@ -1,0 +1,78 @@
+package bdbe.bdbd.pay;
+
+
+import bdbe.bdbd.reservation.Reservation;
+import lombok.Getter;
+import lombok.Setter;
+
+public class PayResponse {
+
+    @Getter
+    @Setter
+    public static class PayReadyResponseDTO {
+        private String tid;
+        private Boolean tms_result;
+        private String next_redirect_app_url;
+        private String next_redirect_mobile_url;
+        private String next_redirect_pc_url;
+        private String android_app_scheme;
+        private String ios_app_scheme;
+        private String created_at;
+    }
+
+    @Getter
+    @Setter
+    public static class PayApprovalResponseDTO {
+        private String aid;
+        private String tid;
+        private String cid;
+        private String partner_order_id;
+        private String partner_user_id;
+        private String payment_method_type;
+        private String item_name;
+        private Integer quantity;
+        private Amount amount;
+        private String created_at;
+        private String approved_at;
+    }
+
+    @Getter
+    @Setter
+    public static class Amount {
+        private Integer total;
+        private Integer tax_free;
+        private Integer vat;
+        private Integer point;
+        private Integer discount;
+        private Integer green_deposit;
+    }
+    @Getter
+    @Setter
+    public static class CardInfo {
+        private String purchase_corp;
+        private String purchase_corp_code;
+        private String issuer_corp;
+        private String issuer_corp_code;
+        private String kakaopay_purchase_corp;
+        private String kakaopay_purchase_corp_code;
+        private String kakaopay_issuer_corp;
+        private String kakaopay_issuer_corp_code;
+        private String bin;
+        private String card_type;
+        private String install_month;
+        private String approved_id;
+        private String card_mid;
+        private String interest_free_install;
+        private String card_item_code;
+    }
+
+    @Getter
+    @Setter
+    public static class PaymentAndReservationResponseDTO {
+        private String paymentApprovalResponse;
+        private Reservation reservation;
+    }
+
+
+
+}

--- a/src/main/java/bdbe/bdbd/pay/PayService.java
+++ b/src/main/java/bdbe/bdbd/pay/PayService.java
@@ -1,0 +1,114 @@
+package bdbe.bdbd.pay;
+
+import bdbe.bdbd._core.errors.exception.BadRequestError;
+import bdbe.bdbd.carwash.Carwash;
+import bdbe.bdbd.member.Member;
+import bdbe.bdbd.reservation.Reservation;
+import bdbe.bdbd.reservation.ReservationRequest;
+import bdbe.bdbd.reservation.ReservationService;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+
+@Slf4j
+@Service
+public class PayService {
+
+    @Value("${kakao.admin.key}")
+    private String adminKey;
+
+    @Value("${payment.approval-url}")
+    private String approval_url;
+
+    @Value("${payment.cancel-url}")
+    private String cancel_url;
+
+    @Value("${payment.fail-url}")
+    private String fail_url;
+
+
+    @Autowired
+    private ReservationService reservationService;
+
+
+    public ResponseEntity<String> requestPaymentReady(PayRequest.PayReadyRequestDTO requestDto, ReservationRequest.SaveDTO saveDTO, Carwash carwash) {
+        RestTemplate restTemplate = new RestTemplate();
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+        headers.set("Authorization", "KakaoAK " + adminKey);
+
+        PayRequest.PayReadyRequestDTO payReadyRequestDTO = PayRequest.PayReadyRequestDTO.fromSaveDTO(saveDTO, carwash);
+        requestDto.setTotal_amount(payReadyRequestDTO.getTotal_amount());
+        requestDto.setVat_amount(payReadyRequestDTO.getVat_amount());
+        log.info("Request DTO: " + requestDto.toString());
+
+
+        MultiValueMap<String, String> parameters = new LinkedMultiValueMap<>();
+        parameters.add("cid", requestDto.getCid());
+        parameters.add("partner_order_id", requestDto.getPartner_order_id());
+        parameters.add("partner_user_id", requestDto.getPartner_user_id());
+        parameters.add("item_name", requestDto.getItem_name());
+        parameters.add("quantity", requestDto.getQuantity().toString());
+        parameters.add("total_amount", requestDto.getTotal_amount().toString());
+        parameters.add("vat_amount", requestDto.getVat_amount().toString());
+        parameters.add("tax_free_amount", requestDto.getTax_free_amount().toString());
+        parameters.add("approval_url", approval_url);
+        parameters.add("cancel_url", cancel_url);
+        parameters.add("fail_url", fail_url);
+        log.info("Parameters: " + parameters.toString());
+
+
+        HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(parameters, headers);
+        String url = "https://kapi.kakao.com/v1/payment/ready";
+
+        return restTemplate.postForEntity(url, request, String.class);
+    }
+
+    public ResponseEntity<PayResponse.PaymentAndReservationResponseDTO> requestPaymentApproval(
+            PayRequest.PayApprovalRequestDTO requestDto,
+            Long carwashId,
+            Long bayId,
+            Member sessionMember,
+            ReservationRequest.SaveDTO saveDTO) {
+
+        RestTemplate restTemplate = new RestTemplate();
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+        headers.set("Authorization", "KakaoAK " + adminKey);
+
+        MultiValueMap<String, String> parameters = new LinkedMultiValueMap<>();
+        parameters.add("cid", requestDto.getCid());
+        parameters.add("tid", requestDto.getTid());
+        parameters.add("partner_order_id", requestDto.getPartner_order_id());
+        parameters.add("partner_user_id", requestDto.getPartner_user_id());
+        parameters.add("pg_token", requestDto.getPg_token());
+
+        HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(parameters, headers);
+        String url = "https://kapi.kakao.com/v1/payment/approve";
+
+        ResponseEntity<String> paymentApprovalResponse = restTemplate.postForEntity(url, request, String.class);
+
+        PayResponse.PaymentAndReservationResponseDTO responseDto = new PayResponse.PaymentAndReservationResponseDTO();
+        responseDto.setPaymentApprovalResponse(paymentApprovalResponse.getBody());
+
+        if (paymentApprovalResponse.getStatusCode().is2xxSuccessful()) {
+            Reservation reservation = reservationService.save(saveDTO, carwashId, bayId, sessionMember);
+            responseDto.setReservation(reservation);
+        } else {
+            log.error("Payment approval failed: " + paymentApprovalResponse.getBody());
+            throw new BadRequestError("Payment approval failed");
+
+        }
+        return ResponseEntity.ok(responseDto);
+    }
+}

--- a/src/main/java/bdbe/bdbd/pay/PayService.java
+++ b/src/main/java/bdbe/bdbd/pay/PayService.java
@@ -45,6 +45,9 @@ public class PayService {
     private ReservationService reservationService;
 
     @Autowired
+    private RestTemplate restTemplate;
+
+    @Autowired
     private CarwashJPARepository carwashJpaRepository;
 
     public ResponseEntity<String> requestPaymentReady(PayRequest.PayReadyRequestDTO requestDto, ReservationRequest.SaveDTO saveDTO, Long carwashId) {
@@ -68,7 +71,7 @@ public class PayService {
         dto.setTotal_amount(totalAmount);
 //        dto.setVat_amount(vatAmount);
 
-        RestTemplate restTemplate = new RestTemplate();
+//        RestTemplate restTemplate = new RestTemplate();
 
 
         HttpHeaders headers = new HttpHeaders();
@@ -100,6 +103,7 @@ public class PayService {
 
         return restTemplate.postForEntity(url, request, String.class);
     }
+
     @Transactional
     public ResponseEntity<ReservationResponse.findLatestOneResponseDTO> requestPaymentApproval(
             PayRequest.PayApprovalRequestDTO requestDto,
@@ -108,7 +112,7 @@ public class PayService {
             Member member,  // 변수 이름 변경
             ReservationRequest.SaveDTO saveDTO) {
 
-        RestTemplate restTemplate = new RestTemplate();
+//        RestTemplate restTemplate = new RestTemplate();
 
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);

--- a/src/main/java/bdbe/bdbd/pay/PayService.java
+++ b/src/main/java/bdbe/bdbd/pay/PayService.java
@@ -2,9 +2,11 @@ package bdbe.bdbd.pay;
 
 import bdbe.bdbd._core.errors.exception.BadRequestError;
 import bdbe.bdbd.carwash.Carwash;
+import bdbe.bdbd.carwash.CarwashJPARepository;
 import bdbe.bdbd.member.Member;
 import bdbe.bdbd.reservation.Reservation;
 import bdbe.bdbd.reservation.ReservationRequest;
+import bdbe.bdbd.reservation.ReservationResponse;
 import bdbe.bdbd.reservation.ReservationService;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -14,9 +16,13 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestTemplate;
+
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
 
 @Slf4j
 @Service
@@ -38,19 +44,41 @@ public class PayService {
     @Autowired
     private ReservationService reservationService;
 
+    @Autowired
+    private CarwashJPARepository carwashJpaRepository;
 
-    public ResponseEntity<String> requestPaymentReady(PayRequest.PayReadyRequestDTO requestDto, ReservationRequest.SaveDTO saveDTO, Carwash carwash) {
+    public ResponseEntity<String> requestPaymentReady(PayRequest.PayReadyRequestDTO requestDto, ReservationRequest.SaveDTO saveDTO, Long carwashId) {
+
+        Carwash carwash = carwashJpaRepository.findById(carwashId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 세차장이 존재하지 않습니다. id=" + carwashId));
+
+        int perPrice = carwash.getPrice();
+        LocalDateTime startTime = saveDTO.getStartTime();
+        LocalDateTime endTime = saveDTO.getEndTime();
+        System.out.println(saveDTO.toString());
+
+        int minutesDifference = (int) ChronoUnit.MINUTES.between(startTime, endTime);
+        int blocksOf30Minutes = minutesDifference / 30;
+        int price = perPrice * blocksOf30Minutes;
+
+        int totalAmount = price;  //세금 포함 가격
+//        int vatAmount = (int)(price * 0.1);  // 세금
+
+        PayRequest.PayReadyRequestDTO dto = new PayRequest.PayReadyRequestDTO();
+        dto.setTotal_amount(totalAmount);
+//        dto.setVat_amount(vatAmount);
+
         RestTemplate restTemplate = new RestTemplate();
+
 
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
         headers.set("Authorization", "KakaoAK " + adminKey);
 
-        PayRequest.PayReadyRequestDTO payReadyRequestDTO = PayRequest.PayReadyRequestDTO.fromSaveDTO(saveDTO, carwash);
-        requestDto.setTotal_amount(payReadyRequestDTO.getTotal_amount());
-        requestDto.setVat_amount(payReadyRequestDTO.getVat_amount());
+        PayRequest.PayReadyRequestDTO payReadyRequestDTO = new PayRequest.PayReadyRequestDTO();
+        requestDto.setTotal_amount(totalAmount);
+//        requestDto.setVat_amount(vatAmount);
         log.info("Request DTO: " + requestDto.toString());
-
 
         MultiValueMap<String, String> parameters = new LinkedMultiValueMap<>();
         parameters.add("cid", requestDto.getCid());
@@ -59,7 +87,7 @@ public class PayService {
         parameters.add("item_name", requestDto.getItem_name());
         parameters.add("quantity", requestDto.getQuantity().toString());
         parameters.add("total_amount", requestDto.getTotal_amount().toString());
-        parameters.add("vat_amount", requestDto.getVat_amount().toString());
+//        parameters.add("vat_amount", requestDto.getVat_amount().toString());
         parameters.add("tax_free_amount", requestDto.getTax_free_amount().toString());
         parameters.add("approval_url", approval_url);
         parameters.add("cancel_url", cancel_url);
@@ -72,12 +100,12 @@ public class PayService {
 
         return restTemplate.postForEntity(url, request, String.class);
     }
-
-    public ResponseEntity<PayResponse.PaymentAndReservationResponseDTO> requestPaymentApproval(
+    @Transactional
+    public ResponseEntity<ReservationResponse.findLatestOneResponseDTO> requestPaymentApproval(
             PayRequest.PayApprovalRequestDTO requestDto,
             Long carwashId,
             Long bayId,
-            Member sessionMember,
+            Member member,  // 변수 이름 변경
             ReservationRequest.SaveDTO saveDTO) {
 
         RestTemplate restTemplate = new RestTemplate();
@@ -98,17 +126,20 @@ public class PayService {
 
         ResponseEntity<String> paymentApprovalResponse = restTemplate.postForEntity(url, request, String.class);
 
-        PayResponse.PaymentAndReservationResponseDTO responseDto = new PayResponse.PaymentAndReservationResponseDTO();
-        responseDto.setPaymentApprovalResponse(paymentApprovalResponse.getBody());
+//        PayResponse.PaymentAndReservationResponseDTO responseDto = new PayResponse.PaymentAndReservationResponseDTO();
+//        responseDto.setPaymentApprovalResponse(paymentApprovalResponse.getBody());
+
+        Reservation reservation;
 
         if (paymentApprovalResponse.getStatusCode().is2xxSuccessful()) {
-            Reservation reservation = reservationService.save(saveDTO, carwashId, bayId, sessionMember);
-            responseDto.setReservation(reservation);
+            reservation = reservationService.save(saveDTO, carwashId, bayId, member);  // 변수 이름 변경
         } else {
             log.error("Payment approval failed: " + paymentApprovalResponse.getBody());
             throw new BadRequestError("Payment approval failed");
-
         }
+        ReservationResponse.findLatestOneResponseDTO responseDto = reservationService.fetchLatestReservation(reservation.getId());
         return ResponseEntity.ok(responseDto);
+
     }
+
 }

--- a/src/main/java/bdbe/bdbd/reservation/ReservationResponse.java
+++ b/src/main/java/bdbe/bdbd/reservation/ReservationResponse.java
@@ -14,6 +14,7 @@ import javax.persistence.Column;
 import java.awt.*;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -67,15 +68,15 @@ public class ReservationResponse {
     public static class findLatestOneResponseDTO {
         private ReservationDTO reservation;
         private CarwashDTO carwash;
-        public findLatestOneResponseDTO(Reservation reservation, Bay bay, Carwash carwash, Location location, List<File> carwashImages) {
+        public findLatestOneResponseDTO(Reservation reservation, Bay bay, Carwash carwash, Location location, File carwashImage) {
             ReservationDTO reservationDTO = new ReservationDTO();
-
             TimeDTO timeDTO = new TimeDTO();
             timeDTO.start = reservation.getStartTime();
             timeDTO.end = reservation.getEndTime();
             reservationDTO.time = timeDTO;
             reservationDTO.price = reservation.getPrice();
             reservationDTO.bayNo = bay.getBayNum();
+            reservationDTO.reservationId = reservation.getId();
             this.reservation = reservationDTO;
 
             CarwashDTO carwashDTO = new CarwashDTO();
@@ -84,9 +85,7 @@ public class ReservationResponse {
             locationDTO.latitude = location.getLatitude();
             locationDTO.longitude = location.getLongitude();
             carwashDTO.location = locationDTO;
-            carwashDTO.carwashImages = carwashImages.stream()
-                    .map(ImageDTO::new)
-                    .collect(Collectors.toList());
+            carwashDTO.carwashImages = (carwashImage != null) ? Collections.singletonList(new ImageDTO(carwashImage)) : Collections.emptyList();
             this.carwash = carwashDTO;
         }
     }
@@ -94,6 +93,7 @@ public class ReservationResponse {
     @Setter
     @ToString
     public static class ReservationDTO {
+        private Long reservationId;
         private TimeDTO time;
         private int price;
         private int bayNo; // 예약된 베이 번호

--- a/src/main/java/bdbe/bdbd/reservation/ReservationRestController.java
+++ b/src/main/java/bdbe/bdbd/reservation/ReservationRestController.java
@@ -61,16 +61,16 @@ public class ReservationRestController {
 
     }
 
-    // 결제 후 예약 내역 조회
-    @GetMapping("/reservations")
-    public ResponseEntity<?> fetchLatestReservation(
-            @AuthenticationPrincipal CustomUserDetails userDetails
-    )
-    {
-        ReservationResponse.findLatestOneResponseDTO dto = reservationService.fetchLatestReservation(userDetails.getMember());
-        System.out.println(dto.toString());
-        return ResponseEntity.ok(ApiUtils.success(dto));
-    }
+//    // 결제 후 예약 내역 조회
+//    @GetMapping("/reservations")
+//    public ResponseEntity<?> fetchLatestReservation(
+//            @AuthenticationPrincipal CustomUserDetails userDetails
+//    )
+//    {
+//        ReservationResponse.findLatestOneResponseDTO dto = reservationService.fetchLatestReservation();
+//        System.out.println(dto.toString());
+//        return ResponseEntity.ok(ApiUtils.success(dto));
+//    }
 
     // 현재 시간 기준 예약 내역 조회
     @GetMapping("/reservations/current-status")

--- a/src/main/java/bdbe/bdbd/reservation/ReservationService.java
+++ b/src/main/java/bdbe/bdbd/reservation/ReservationService.java
@@ -145,9 +145,9 @@ public class ReservationService {
         return new ReservationResponse.findAllResponseDTO(bayList, reservationList);
     }
 
-    public ReservationResponse.findLatestOneResponseDTO fetchLatestReservation(Member sessionMember) {
+    public ReservationResponse.findLatestOneResponseDTO fetchLatestReservation(Long reservationId) {
         // 가장 최근의 예약 찾기
-        Reservation reservation = reservationJPARepository.findTopByMemberIdOrderByIdDesc(sessionMember.getId())
+        Reservation reservation = reservationJPARepository.findById(reservationId)
                 .filter(r -> !r.isDeleted())
                 .orElseThrow(() -> new NoSuchElementException("no reservation found"));
         // 예약과 관련된 베이 찾기
@@ -159,8 +159,9 @@ public class ReservationService {
         // 세차장이 위치한 위치 찾기
         Location location = locationJPARepository.findById(carwash.getLocation().getId())
                 .orElseThrow(() -> new NoSuchElementException("no location found"));
-        List<File> carwashImages = fileJPARepository.findByCarwash_Id(carwash.getId());
-        return new ReservationResponse.findLatestOneResponseDTO(reservation, bay, carwash, location, carwashImages);
+
+        File file = fileJPARepository.findFirstByCarwashIdOrderByUploadedAtAsc(carwash.getId()).orElse(null);
+        return new ReservationResponse.findLatestOneResponseDTO(reservation, bay, carwash, location, file);
     }
 
     public ReservationResponse.fetchCurrentStatusReservationDTO fetchCurrentStatusReservation(Member sessionMember) {

--- a/src/main/java/bdbe/bdbd/reservation/ReservationService.java
+++ b/src/main/java/bdbe/bdbd/reservation/ReservationService.java
@@ -47,7 +47,7 @@ public class ReservationService {
     private final ReviewKeywordJPARepository reviewKeywordJPARepository;
 
     @Transactional
-    public void save(ReservationRequest.SaveDTO dto, Long carwashId, Long bayId, Member sessionMember) {
+    public Reservation save(ReservationRequest.SaveDTO dto, Long carwashId, Long bayId, Member sessionMember) {
         Carwash carwash = findCarwashById(carwashId);
         Optime optime = findOptime(carwash, dto.getStartTime());
 
@@ -56,6 +56,7 @@ public class ReservationService {
 
         Reservation reservation = dto.toReservationEntity(carwash, bay, sessionMember);
         reservationJPARepository.save(reservation);
+        return reservation;
     }
 
     @Transactional

--- a/src/test/java/bdbe/bdbd/pay/PayRestControllerTest.java
+++ b/src/test/java/bdbe/bdbd/pay/PayRestControllerTest.java
@@ -1,0 +1,74 @@
+package bdbe.bdbd.pay;
+
+import bdbe.bdbd.carwash.CarwashJPARepository;
+import bdbe.bdbd.reservation.ReservationRequest;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithUserDetails;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@Transactional
+@AutoConfigureMockMvc
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK)
+public class PayRestControllerTest {
+
+    @Autowired
+    private MockMvc mvc;
+
+    @Autowired
+    CarwashJPARepository carwashJPARepository;
+
+    @Autowired
+    private ObjectMapper om;
+
+    @WithUserDetails("user@nate.com")
+    @Test
+    @DisplayName("Payment Ready Request Test")
+    public void requestPaymentReadyTest() throws Exception {
+
+        Long carwashId = 1L;
+
+        PayRequest.PayReadyRequestDTO requestDto = new PayRequest.PayReadyRequestDTO();
+        requestDto.setCid("TC0ONETIME");
+        requestDto.setPartner_order_id("partner_order_id");
+        requestDto.setPartner_user_id("partner_user_id");
+        requestDto.setItem_name("구름 세차장 예약");
+        requestDto.setQuantity(1);
+        requestDto.setTax_free_amount(0);
+
+        ReservationRequest.SaveDTO saveDTO = new ReservationRequest.SaveDTO();
+        saveDTO.setBayId(1L);
+        saveDTO.setStartTime(LocalDateTime.parse("2024-11-01T14:00:00"));
+        saveDTO.setEndTime(LocalDateTime.parse("2024-11-01T15:00:00"));
+
+        Map<String, Object> requestBodyMap = new HashMap<>();
+        requestBodyMap.put("requestDto", requestDto);
+        requestBodyMap.put("saveDTO", saveDTO);
+
+        String jsonRequestBody = om.writeValueAsString(requestBodyMap);
+
+        ResultActions resultActions = mvc.perform(
+                post("/api/payment/ready/{carwashId}", carwashId)
+                        .content(jsonRequestBody)
+                        .contentType(MediaType.APPLICATION_JSON_VALUE)
+        );
+
+        resultActions.andExpect(status().isOk());
+        resultActions.andExpect(jsonPath("$.tid").exists());
+    }
+}


### PR DESCRIPTION
카카오페이 api를 이용한 결제 기능 구현

예약 정보를 백엔드에 보내고 카카오페이 결제 api를 호출

cid는 테스트를 위한 임시 가맹점 id
필수 body인 total_amount는 내부 로직을 통해 세차장별 가격에 시간을 곱한값을 계산받아 사용한다.
필수 body인 approval_url, fail_url, cancel_url은 yml파일을 통해 결제 진행상황에 따라 반환될 url을 환경변수를 통해 설정한다.

tid는 결제가 성공하면 생성하는 결제고유번호이고

next_redirecti_**_url을 통해서 api가 호출된다.

카카오페이 api 호출이후 성공시 approve_url 에 쿼리 파라미터로 pg_token값을 같이 받는다.

결제와 베이의 예약정보를 넘겨주면 카카오페이 결제 성공이 발생하고, 예약 객체가 생성된다.