### PR TITLE
fix: 이메일 중복 에러 반환 정상화

### DIFF
--- a/src/main/java/bdbe/bdbd/controller/open/OpenMemberController.java
+++ b/src/main/java/bdbe/bdbd/controller/open/OpenMemberController.java
@@ -42,13 +42,6 @@ public class OpenMemberController {
 
     @PostMapping("/login/user")
     public ResponseEntity<?> loginUser(@RequestBody @Valid UserRequest.LoginDTO requestDTO, Errors errors) {
-        if (errors.hasErrors()) {
-            String errorMessage = errors.getAllErrors().get(0).getDefaultMessage();
-            throw new UnAuthorizedError(
-            UnAuthorizedError.ErrorCode.ACCESS_DENIED,
-                    Collections.singletonMap("Token", errorMessage)
-            );
-        }
         UserResponse.LoginResponse response = userService.login(requestDTO);
         return ResponseEntity.ok().header(JWTProvider.HEADER, response.getJwtToken()).body(ApiUtils.success(null));
     }
@@ -61,13 +54,6 @@ public class OpenMemberController {
 
     @PostMapping("/login/owner")
     public ResponseEntity<?> loginOwner(@RequestBody @Valid UserRequest.LoginDTO requestDTO, Errors errors) {
-        if (errors.hasErrors()) {
-            String errorMessage = errors.getAllErrors().get(0).getDefaultMessage();
-            throw new UnAuthorizedError(
-                    UnAuthorizedError.ErrorCode.ACCESS_DENIED,
-                    Collections.singletonMap("Token", errorMessage)
-            );
-        }
         UserResponse.LoginResponse response = ownerService.login(requestDTO);
         return ResponseEntity.ok().header(JWTProvider.HEADER, response.getJwtToken()).body(ApiUtils.success(null));
     }

--- a/src/main/java/bdbe/bdbd/service/member/UserService.java
+++ b/src/main/java/bdbe/bdbd/service/member/UserService.java
@@ -65,10 +65,9 @@ public class UserService {
     public void sameCheckEmail(String email) {
         Optional<Member> userOP = memberJPARepository.findByEmail(email);
         if (userOP.isPresent()) {
-            throw new UnAuthorizedError(
-                    UnAuthorizedError.ErrorCode.AUTHENTICATION_FAILED,
-                    Collections.singletonMap("Password", "Wrong password")
-            );
+            throw new BadRequestError(
+                    BadRequestError.ErrorCode.DUPLICATE_RESOURCE,
+                    Collections.singletonMap("Email", "Duplicate email exist : " + email));
         }
     }
 


### PR DESCRIPTION
이메일 중복 검증 시 정상 에러를 반환하도록 수정했습니다.
validationHandler에서 중복 로직을 삭제하여 코드 가독성과 유지보수성을 향상시켰습니다.
